### PR TITLE
Fixed support for python 3.8 can't use 'is' for comparing equality

### DIFF
--- a/app.py
+++ b/app.py
@@ -79,7 +79,7 @@ def list_camps(resource_category_id):
     return camps
 
 def init_camp_details():
-    if(len(CAMP_DETAILS_BY_LOCATIONID) is 0):
+    if(len(CAMP_DETAILS_BY_LOCATIONID) == 0):
         all_camp_details = get_json('CAMP_DETAILS_ALL')
         for camp_details in all_camp_details:
             CAMP_DETAILS_BY_LOCATIONID[camp_details['resourceLocationId']] = camp_details['localizedValues']


### PR DESCRIPTION
Hello, thank you for creating this project it's very useful. I ran into an error when using python 3.8: "SyntaxWarning: "is" here is a fix.